### PR TITLE
Exponential backoff on reconnect

### DIFF
--- a/plugins/ReConnect.py
+++ b/plugins/ReConnect.py
@@ -11,6 +11,8 @@ class ReConnectPlugin:
 		client.register_handler(self.stop, cflags['KILL_EVENT'])
 		client.register_dispatch(self.reconnect, 0xFF)
 		client.register_dispatch(self.grab_host, 0x02)
+		client.register_dispatch(self.reset_reconnect_time, 0x01)
+		self.reset_reconnect_time()
 
 	def session_reconnect(self, *args):
 		if not self.kill:
@@ -19,7 +21,13 @@ class ReConnectPlugin:
 
 	def reconnect(self, *args):
 		if not self.kill:
+			sleep(self.delay)
+			if self.delay < 300:
+				self.delay = self.delay * 2
 			self.client.login(self.host, self.port)
+
+	def reset_reconnect_time(self, *args):
+		self.delay = 1.18
 
 	#Grabs host and port on handshake
 	def grab_host(self, packet):


### PR DESCRIPTION
This adds exponential backoff to the reconnect plugin. It waits an increasing period of time after each failure, capped at 5 minutes.
