### PR TITLE
headY/feetY protocol fix

### DIFF
--- a/spock/mcp/mcdata.py
+++ b/spock/mcp/mcdata.py
@@ -766,8 +766,8 @@ packet_structs = {
             #Player Position and Look
             0x06: (
                 (MC_DOUBLE, 'x'),
-                (MC_DOUBLE, 'stance'),
                 (MC_DOUBLE, 'y'),
+                (MC_DOUBLE, 'stance'),
                 (MC_DOUBLE, 'z'),
                 (MC_FLOAT, 'yaw'),
                 (MC_FLOAT, 'pitch'),


### PR DESCRIPTION
Both my packet sniffer and http://wiki.vg/Protocol indicate that the correct order of fields for packet type 0x06 is x, feetY, headY (stance), z -- not x, headY (stance), feetY, z.
Please double-check this with a real bot.
There might be something similar going on for 0x04...
