### PR TITLE
Fix for handler re-registration re-execution

### DIFF
--- a/spock/plugins/core/event.py
+++ b/spock/plugins/core/event.py
@@ -28,7 +28,11 @@ class EventCore:
 
 	def emit(self, event, data = None):
 		to_remove = []
-		for handler in self.event_handlers[event]:
+		# reversed, because handlers can register themselves
+		# for the same event they handle, and the new handler
+		# is appended to the end of the iterated handler list
+		# and immediately run, so an infinite loop can be created
+		for handler in reversed(self.event_handlers[event]):
 			if handler(
 				event,
 				data.clone() if hasattr(data, 'clone') else copy.deepcopy(data)

--- a/spock/plugins/core/event.py
+++ b/spock/plugins/core/event.py
@@ -1,10 +1,10 @@
 """
 Provides the core event loop
 """
+from collections import defaultdict
 
 import signal
 import copy
-from spock.mcp import mcdata
 from spock.utils import pl_announce
 
 import logging
@@ -13,7 +13,7 @@ logger = logging.getLogger('spock')
 class EventCore:
 	def __init__(self):
 		self.kill_event = False
-		self.event_handlers = {}
+		self.event_handlers = defaultdict(list)
 		signal.signal(signal.SIGINT, self.kill)
 		signal.signal(signal.SIGTERM, self.kill)
 
@@ -24,13 +24,9 @@ class EventCore:
 		self.emit('kill')
 
 	def reg_event_handler(self, event, handler):
-		if event not in self.event_handlers:
-			self.event_handlers[event] = []
 		self.event_handlers[event].append(handler)
 
 	def emit(self, event, data = None):
-		if event not in self.event_handlers:
-			self.event_handlers[event] = []
 		to_remove = []
 		for handler in self.event_handlers[event]:
 			if handler(


### PR DESCRIPTION
Makes it possible for handlers to register themselves again to the same event they handle.
At the moment, these handlers get called again before the next event is thrown.
This is needed to create more flexible events, especially for crafting.

#### Example:

`handler` is registered for `some_event`.
On execution, `handler` registers itself again for `some_event`.
(This can be useful if the event `handler` is registered to should change after it is run.)

When `some_event` is emitted, `handler` is [added to the end of the event handlers list](https://github.com/SpockBotMC/SpockBot/blob/80d6f2d6c08cfa26a60133ba9909846cffaddf4d/spock/plugins/core/event.py#L29).
Because the [mutable list is iterated](https://github.com/SpockBotMC/SpockBot/blob/80d6f2d6c08cfa26a60133ba9909846cffaddf4d/spock/plugins/core/event.py#L35), and not a copy, the iterator sooner or later reaches the newly registered `handler` and runs it, although no event has been emitted during the two `handler` calls.