### PR TITLE
Fix the int cast in smpmap.dimension.get_block

### DIFF
--- a/spock/mcmap/smpmap.py
+++ b/spock/mcmap/smpmap.py
@@ -174,7 +174,7 @@ class Dimension(object):
 		self.columns[key].unpack(bbuff, mask, skylight, continuous)
 
 	def get_block(self, x, y, z):
-		x, y, z = int(x), int(y), int(z) #Damn you python2
+		x, y, z = utils.mcint(x), utils.mcint(y), utils.mcint(z) #Damn you python2
 		x, rx = divmod(x, 16)
 		y, ry = divmod(y, 16)
 		z, rz = divmod(z, 16)

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -124,5 +124,9 @@ def mapshort2id(data):
 def ByteToHex(byteStr):
 	return ''.join( [ "%02X " % x for x in byteStr ] ).strip()
 
+# this cast is for such case:
+# x,y,z=(-111.5,66,99)
+# in minecraft this point is inside the block(-112,66,99)
+# but if we directly cast it to int, it will be (-111,66,99)
 def mcint(num):
         return int(num)-1 if num < 0 else int(num)

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -123,3 +123,6 @@ def mapshort2id(data):
 
 def ByteToHex(byteStr):
 	return ''.join( [ "%02X " % x for x in byteStr ] ).strip()
+
+def mcint(num):
+        return int(num)-1 if num < 0 else int(num)


### PR DESCRIPTION
the python int cast is different from the behavior in minecraft, for example:
a point (x,y,z)=(-123.7,33,44)
In minecraft this point should be inside the block (-124,33,44).
But in the smpmap.dimension.get_block we use the python int cast, it will cast to (-123,33,44) and get a wrong block data.
So I add a mcint() in utils.py to cast it correctly..
