### PR TITLE
PluginBase

### DIFF
--- a/spock/plugins/helpers/respawn.py
+++ b/spock/plugins/helpers/respawn.py
@@ -3,17 +3,16 @@ RespawnPlugin's scope is huge, only KeepAlivePlugin does more
 """
 
 from spock.mcp import mcdata
+from spock.plugins.plugin_base import BasePlugin
 
 import logging
 logger = logging.getLogger('spock')
 
-class RespawnPlugin:
-	def __init__(self, ploader, settings):
-		self.net = ploader.requires('Net')
-		ploader.requires('ClientInfo')
-		ploader.reg_event_handler(
-			'cl_death', self.handle_death
-		)
+class RespawnPlugin(BasePlugin):
+	requires = ('Net', 'ClientInfo')
+	events = {
+		'cl_death': 'handle_death'
+	}
 
 	#You be dead
 	def handle_death(self, name, data):

--- a/spock/plugins/helpers/respawn.py
+++ b/spock/plugins/helpers/respawn.py
@@ -3,12 +3,12 @@ RespawnPlugin's scope is huge, only KeepAlivePlugin does more
 """
 
 from spock.mcp import mcdata
-from spock.plugins.plugin_base import BasePlugin
+from spock.plugins.plugin_base import PluginBase
 
 import logging
 logger = logging.getLogger('spock')
 
-class RespawnPlugin(BasePlugin):
+class RespawnPlugin(PluginBase):
 	requires = ('Net', 'ClientInfo')
 	events = {
 		'cl_death': 'handle_death'

--- a/spock/plugins/plugin_base.py
+++ b/spock/plugins/plugin_base.py
@@ -1,9 +1,9 @@
 from spock.utils import get_settings
 
-class BasePlugin(object):
+class PluginBase(object):
 	"""A base class for cleaner plugin code.
 
-	Extending from BasePlugin allows you to declare any requirements, default
+	Extending from PluginBase allows you to declare any requirements, default
 	settings, and event listeners in a declarative way. Define the appropriate
 	attributes on your subclass and enjoy cleaner code.
 	"""

--- a/spock/plugins/plugin_base.py
+++ b/spock/plugins/plugin_base.py
@@ -1,0 +1,21 @@
+from ..utils import get_settings
+
+class BasePlugin(object):
+	requires = ()
+	defaults = {}
+	events = {}
+
+	def __init__(self, ploader, settings):
+		# Load the plugin's settings.
+		self.settings = get_settings(self.defaults, settings)
+
+		# Load all the plugin's dependencies.
+		for requirement in self.requires:
+			setattr(self, requirement.lower(), ploader.requires(requirement))
+
+		# Setup the plugin's event handlers.
+		for event in self.events.keys():
+			if hasattr(self, self.events[event]):
+				ploader.reg_event_handler(event, getattr(self, self.events[event]))
+			else:
+				pass  # Do something useful here, like logging it.

--- a/spock/plugins/plugin_base.py
+++ b/spock/plugins/plugin_base.py
@@ -1,6 +1,12 @@
 from ..utils import get_settings
 
 class BasePlugin(object):
+	"""A base class for cleaner plugin code.
+
+	Extending from BasePlugin allows you to declare any requirements, default
+	settings, and event listeners in a declarative way. Define the appropriate
+	attributes on your subclass and enjoy cleaner code.
+	"""
 	requires = ()
 	defaults = {}
 	events = {}

--- a/spock/plugins/plugin_base.py
+++ b/spock/plugins/plugin_base.py
@@ -1,4 +1,4 @@
-from ..utils import get_settings
+from spock.utils import get_settings
 
 class BasePlugin(object):
 	"""A base class for cleaner plugin code.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'jasperbok'

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'jasperbok'

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+from spock.plugins.plugin_base import PluginBase
+
+class PluginLoaderMock(object):
+	events = {}
+
+	def requires(self, *args, **kwargs):
+		return True
+
+	def reg_event_handler(self, event, handler):
+		self.events[event] = [] if event not in self.events else self.events[event]
+		self.events[event].append(handler)
+
+class TestPluginBase(PluginBase):
+	requires = ('Net', 'Auth')
+	defaults = {'foo': 'bar'}
+	events = {'test': 'callback'}
+
+	def callback(self):
+		pass
+
+class PluginBaseTest(TestCase):
+	def setUp(self):
+		self.ploader = PluginLoaderMock()
+		self.plug = TestPluginBase(self.ploader, {})
+
+	def tearDown(self):
+		delattr(self, 'ploader')
+		delattr(self, 'plug')
+
+	def test_requirements_get_loaded(self):
+		self.assertTrue(getattr(self.plug, 'net', False))
+		self.assertTrue(getattr(self.plug, 'auth', False))
+
+	def test_default_settings_applied(self):
+		# Only assert that settings are set. Checking whether settings and
+		# defaults merge correctly should be tested in
+		# spock.utils.get_settings.
+		self.assertEqual(self.plug.settings['foo'], 'bar')
+
+	def test_event_listeners_registration_succeeds(self):
+		self.assertIn(self.plug.callback, self.ploader.events['test'])


### PR DESCRIPTION
I'm not online at IRC all the time, so might miss comments there. Thought I'd create a pull request so you can leave any comments here.

So about my changes:
`PluginBase` basically provides a base class to build plugins upon. The current implementation simply enables the developer to declare their plugin's event handlers, requirements and setting defaults as attributes, instead of making multiple function calls. In my personal opinion this makes plugin code cleaner and more readable.

For simple plugins it makes defining an `__init__()` method unnecessary and for more complex plugins it can shortly reduce the length of the method.

A secondary benefit would be that by extending from `PluginBase`, your plugin automatically inherits from `object` as well, which doesn't make much of a difference for py3, but in py2 the current implementations of core plugins are created as old-style classes, which might be problematic.

Beside the `PluginBase` class I also created some unit tests for it. Keep in mind that I haven't written much testcases in the past, so they may be no good at all. I'm in a very premature learning phase when it comes to tests.

I refactored the `RespawnPlugin` as kind of a real world testcase, and it seems to work pretty well. I'm aware that this class is very small, but if the idea behind `PluginBase` is accepted I'm very willing to restructure the other plugins as well.

Anyway, whether the pull request gets accepted or not, constructive comments are very welcome indeed! This is my first time contributing to an open source project, so I'll take any chance to learn ;)