### PR TITLE
Add inplace operations for CartesianVector

### DIFF
--- a/spock/vector.py
+++ b/spock/vector.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import math
 
 
@@ -35,7 +37,9 @@ class CartesianVector(BaseVector):
     def __add__(self, other):
         return self.__class__(*map(sum, zip(self, other)))
 
-    __iadd__ = __add__
+    def __iadd__(self, other):
+        self.vector = list(map(sum, zip(self, other)))
+        return self
 
     def __neg__(self):
         return self.__class__(*map(lambda a: -a, self))
@@ -43,18 +47,25 @@ class CartesianVector(BaseVector):
     def __sub__(self, other):
         return self.__class__(*map(lambda a: a[0] - a[1], zip(self, other)))
 
-    __isub__ = __sub__
+    def __isub__(self, other):
+        self.vector = list(map(lambda a: a[0] - a[1], zip(self, other)))
+        return self
 
     def __mul__(self, other):
         return self.__class__(*map(lambda a: a * other, self))
 
-    __imul__ = __mul__
+    def __imul__(self, other):
+        self.vector = list(map(lambda a: a * other, self))
+        return self
+
     __rmul__ = __mul__
 
     def __truediv__(self, other):
         return self.__class__(*map(lambda a: a / other, self))
 
-    __itruediv__ = __truediv__
+    def __itruediv__(self, other):
+        self.vector = list(map(lambda a: a / other, self))
+        return self
 
     # More advanced math
 

--- a/spock/vector.py
+++ b/spock/vector.py
@@ -67,6 +67,9 @@ class CartesianVector(BaseVector):
         self.vector = list(map(lambda a: a / other, self))
         return self
 
+    __div__ = __truediv__
+    __idiv__ = __itruediv__
+
     # More advanced math
 
     def trunc(self):

--- a/spock/vector.py
+++ b/spock/vector.py
@@ -41,6 +41,8 @@ class CartesianVector(BaseVector):
         self.vector = list(map(sum, zip(self, other)))
         return self
 
+    iadd = __iadd__
+
     def __neg__(self):
         return self.__class__(*map(lambda a: -a, self))
 
@@ -51,6 +53,8 @@ class CartesianVector(BaseVector):
         self.vector = list(map(lambda a: a[0] - a[1], zip(self, other)))
         return self
 
+    isub = __isub__
+
     def __mul__(self, other):
         return self.__class__(*map(lambda a: a * other, self))
 
@@ -58,6 +62,7 @@ class CartesianVector(BaseVector):
         self.vector = list(map(lambda a: a * other, self))
         return self
 
+    imul = __imul__
     __rmul__ = __mul__
 
     def __truediv__(self, other):
@@ -67,8 +72,10 @@ class CartesianVector(BaseVector):
         self.vector = list(map(lambda a: a / other, self))
         return self
 
+    itruediv = __itruediv__
     __div__ = __truediv__
     __idiv__ = __itruediv__
+    idiv = __idiv__
 
     # More advanced math
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,116 @@
+from spock.vector import CartesianVector
+
+
+def test_cartesianvector_add():
+    v1 = CartesianVector(-1, 2, 1)
+
+    v2 = v1 + v1
+
+    # make sure they are not the same object
+    assert v2 is not v1
+
+    assert len(v2) == 3
+    assert v2[0] == -2
+    assert v2[1] == 4
+    assert v2[2] == 2
+
+
+def test_cartesianvector_iadd():
+    v1 = CartesianVector(-1, 2, 1)
+
+    vbackup = v1
+    v1 += v1
+
+    # make sure same object
+    assert v1 is vbackup
+
+    assert len(v1) == 3
+    assert v1[0] == -2
+    assert v1[1] == 4
+    assert v1[2] == 2
+
+
+def test_cartesianvector_sub():
+    v1 = CartesianVector(-1, 2, 5)
+    v2 = CartesianVector(5, 4, 3)
+    v3 = v1 - v2
+
+    # make sure they are not the same object
+    assert v3 is not v1
+    assert v3 is not v2
+
+    assert len(v3) == 3
+    assert v3[0] == -6
+    assert v3[1] == -2
+    assert v3[2] == 2
+
+
+def test_cartesianvector_isub():
+    v1 = CartesianVector(-1, 2, 5)
+    v2 = CartesianVector(5, 4, 3)
+
+    vbackup = v1
+    v1 -= v2
+
+    # make sure same object
+    assert v1 is vbackup
+    assert v1 is not v2
+
+    assert len(v1) == 3
+    assert v1[0] == -6
+    assert v1[1] == -2
+    assert v1[2] == 2
+
+
+def test_cartesianvector_mul():
+    v1 = CartesianVector(1, 2)
+
+    v2 = v1 * 2
+
+    assert v2 is not v1
+
+    assert len(v2) == 2
+    assert v2[0] == 2
+    assert v2[1] == 4
+
+
+def test_cartesianvector_imul():
+    v1 = CartesianVector(1, 2)
+
+    vbackup = v1
+    v1 *= 2
+
+    assert v1 is vbackup
+
+    assert len(v1) == 2
+    assert v1[0] == 2
+    assert v1[1] == 4
+
+
+def test_cartesianvector_div():
+    v1 = CartesianVector(1, 4)
+
+    v2 = v1 / 2
+
+    assert v2 is not v1
+
+    assert len(v2) == 2
+    # because we 'from __future__ import division' in vector.py
+    # py2 and py3 should be the same
+    assert v2[0] == 0.5
+    assert v2[1] == 2.0
+
+
+def test_cartesianvector_idiv():
+    v1 = CartesianVector(1, 4)
+
+    vbackup = v1
+    v1 /= 2
+
+    assert v1 is vbackup
+
+    assert len(v1) == 2
+    # because we 'from __future__ import division' in vector.py
+    # py2 and py3 should be the same
+    assert v1[0] == 0.5
+    assert v1[1] == 2.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py27, py30, py31, py32, py33, py34, flake8
 
 [testenv]
-sitepackages = true
 commands =
     py.test \
         --basetemp={envtmpdir} \


### PR DESCRIPTION
This is so in the physics plugin we can avoid returning a new Vector3
object every time.
Also added some basic tests for the CartesianVector