### PR TITLE
Fix for crash in #75

### DIFF
--- a/spock/mcp/datautils.py
+++ b/spock/mcp/datautils.py
@@ -211,7 +211,7 @@ def unpack(data_type, bbuff):
     elif data_type == MC_POSITION:
         return unpack_position(bbuff)
     elif data_type == MC_STRING:
-        return bbuff.recv(unpack(MC_VARINT, bbuff)).decode('utf-8')
+        return bbuff.recv(unpack(MC_VARINT, bbuff)).decode('utf-8', 'replace')
     elif data_type == MC_CHAT:
         return json.loads(unpack(MC_STRING, bbuff))
     elif data_type == MC_SLOT:
@@ -240,7 +240,7 @@ def pack(data_type, data):
     elif data_type == MC_POSITION:
         return pack_position(data)
     elif data_type == MC_STRING:
-        data = data.encode('utf-8')
+        data = data.encode('utf-8', 'replace')
         return pack(MC_VARINT, len(data)) + data
     elif data_type == MC_CHAT:
         return pack(MC_STRING, json.dumps(data))

--- a/spock/mcp/yggdrasil.py
+++ b/spock/mcp/yggdrasil.py
@@ -19,12 +19,12 @@ class YggAuth(object):
         try:
             resp = urlopen(Request(
                 url='https://authserver.mojang.com' + endpoint,
-                data=json.dumps(payload).encode(),
+                data=json.dumps(payload).encode('utf-8'),
                 headers={'Content-Type': 'application/json'})
             )
         except HTTPError as e:
             resp = e
-        data = resp.read().decode()
+        data = resp.read().decode('utf-8')
         return json.loads(data) if data else dict()
 
     def authenticate(self, username=None, password=None, client_token=None):


### PR DESCRIPTION
Armor stand metadata decoding still sometimes fails to decode but this at least fixes the UnicodeDecodeError crash caused by a failed string decode.