### PR TITLE
Fix armor stand decoding

### DIFF
--- a/spock/mcp/datautils.py
+++ b/spock/mcp/datautils.py
@@ -161,9 +161,15 @@ def unpack_metadata(bbuff):
         if 0 <= typ < len(metadata_lookup):
             val = unpack(metadata_lookup[typ], bbuff)
         elif typ == 6:
-            val = [unpack(MC_INT, bbuff)] * 3
+            x = unpack(MC_INT, bbuff)
+            y = unpack(MC_INT, bbuff)
+            z = unpack(MC_INT, bbuff)
+            val = [x, y, z]
         elif typ == 7:
-            val = [unpack(MC_FLOAT, bbuff)] * 3
+            pitch = unpack(MC_FLOAT, bbuff)
+            yaw = unpack(MC_FLOAT, bbuff)
+            roll = unpack(MC_FLOAT, bbuff)
+            val = [pitch, yaw, roll]
         else:
             return None
         metadata.append((key, (typ, val)))


### PR DESCRIPTION
[unpack(MC_FLOAT, bbuff)] * 3 does not run the function three times, it
runs it once and then copies the value three times in the array causing
the rest of the unpack to go sideways.