### PR TITLE
Switch from PyCrypto to cryptography

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ starting to shape up quite nicely, we've got timers, basic physics, and
 the beginnings of a World API.
 
 Spock officially supports Python 3.x on \*nix operating systems and
-requires PyCrypto. It also runs on Windows and under Python 2.7+ but
+requires cryptography_. It also runs on Windows and under Python 2.7+ but
 that's not regularly tested and might break at any given moment. If you
 support one of those use cases and Spock breaks for you, submit an issue
 with a stack trace and we'll try to fix it.
@@ -36,7 +36,7 @@ Dependencies
 ------------
 
 | Python 3.x or Python 2.7.x
-| PyCrypto
+| cryptography_ 0.9+
 
 Installation
 ------------
@@ -91,3 +91,4 @@ The NBT parser and the original protocol implementation came from other projects
    :target: https://travis-ci.org/SpockBotMC/SpockBot
 .. |Coverage Status| image:: https://coveralls.io/repos/SpockBotMC/SpockBot/badge.svg?branch=master&service=github
    :target: https://coveralls.io/github/SpockBotMC/SpockBot?branch=master
+.. _cryptography: https://cryptography.io/

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='https://github.com/SpockBotMC/SpockBot',
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
-        'PyCrypto >= 2.6.1',
+        'cryptography >= 0.9',
         'six',
     ],
     keywords=['minecraft'],

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     pytest-capturelog
     pytest-cov
     pytest-xdist
-    pycrypto
+    cryptography
     six
     mock
 


### PR DESCRIPTION
This switches the crypto library from PyCrypto to the poorly-named but well-designed "cryptography" package.

Some reasons to switch, taken from [a comment](https://github.com/twisted/ldaptor/issues/2#issuecomment-48643965) by one of its authors on another pull req:

> Reasons to prefer PyCA cryptography (bearing in mind I'm one of the authors):
> 
> * Built on top of known cryptography toolkits, which are often faster, particularly on non-traditional platforms (SPARC, ARM, etc.), these toolkits are also more likely to be audited
> * Runs on PyPy
> * More active development
> * Can be `pip install`'d on Windows without needing a C compiler

Another advantage is that is has test coverage.

Cheers