### PR TITLE
Simplify and improve BoundBuffer internals.

### DIFF
--- a/spock/mcp/mcpacket.py
+++ b/spock/mcp/mcpacket.py
@@ -71,7 +71,7 @@ class Packet(object):
             # Extension
             if self.ident in hashed_extensions:
                 hashed_extensions[self.ident].decode_extra(self, pbuff)
-            if pbuff.buff:
+            if len(pbuff) > 0:
                 raise PacketDecodeFailure(self, pbuff)
         except utils.BufferUnderflowException:
             raise PacketDecodeFailure(self, pbuff, True)


### PR DESCRIPTION
Use a cursor to handle saving/reverting of the buffer. This avoids some string-munging in read() and the need to store 2 copies of every packet.

Methods should all return the same thing, but the instance variables are different.