### PR TITLE
DefaultPlugins -> default_plugins

### DIFF
--- a/spock/plugins/__init__.py
+++ b/spock/plugins/__init__.py
@@ -25,4 +25,3 @@ helper_plugins = [
     ('world', world.WorldPlugin),
 ]
 default_plugins = core_plugins + helper_plugins
-DefaultPlugins = default_plugins  # for compatibility

--- a/spock/plugins/core/settings.py
+++ b/spock/plugins/core/settings.py
@@ -1,4 +1,4 @@
-from spock.plugins import DefaultPlugins
+from spock.plugins import default_plugins
 from spock.utils import get_settings, pl_announce
 
 
@@ -18,7 +18,7 @@ class PloaderFetch(object):
 class SettingsPlugin(object):
     def __init__(self, ploader, kwargs):
         settings = get_settings(kwargs.get('settings', {}), kwargs)
-        plugin_list = settings.get('plugins', DefaultPlugins)
+        plugin_list = settings.get('plugins', default_plugins)
         plugins = []
         plugin_settings = {}
         for plugin in plugin_list:


### PR DESCRIPTION
I have converted all of the code in SpockBot and SpockBot-Extras to use the new name for default plugins.