### PR TITLE
Make event names more useful

### DIFF
--- a/examples/basic/example_plugin.py
+++ b/examples/basic/example_plugin.py
@@ -48,7 +48,7 @@ class ExamplePlugin(PluginBase):
         'PLAY<Chat Message': 'chat_event_handler',
         # This event will be triggered after authentication when the bot
         # joins the game
-        'cl_join_game': 'perform_initial_actions',
+        'client_join_game': 'perform_initial_actions',
     }
 
     def __init__(self, ploader, settings):

--- a/spock/plugins/__init__.py
+++ b/spock/plugins/__init__.py
@@ -1,6 +1,6 @@
 from spock.plugins.core import auth, event, net, ticker, timer
-from spock.plugins.helpers import chat, clientinfo, entities, interact, \
-    inventory, keepalive, movement, physics, respawn, start, world
+from spock.plugins.helpers import clientinfo, entities, interact, inventory,\
+    keepalive, movement, physics, respawn, start, world
 
 from spock.plugins.base import PluginBase  # noqa
 
@@ -13,9 +13,8 @@ core_plugins = [
     ('timers', timer.TimerPlugin),
 ]
 helper_plugins = [
-    ('chat', chat.ChatPlugin),
     ('clientinfo', clientinfo.ClientInfoPlugin),
-    ('entities', entities.EntityPlugin),
+    ('entities', entities.EntitiesPlugin),
     ('interact', interact.InteractPlugin),
     ('inventory', inventory.InventoryPlugin),
     ('keepalive', keepalive.KeepalivePlugin),

--- a/spock/plugins/__init__.py
+++ b/spock/plugins/__init__.py
@@ -1,7 +1,6 @@
 from spock.plugins.core import auth, event, net, ticker, timer
-from spock.plugins.helpers import clientinfo, entities, interact, inventory,\
-    keepalive, movement, physics, respawn, start, world
-
+from spock.plugins.helpers import chat, clientinfo, entities, interact, \
+    inventory, keepalive, movement, physics, respawn, start, world
 from spock.plugins.base import PluginBase  # noqa
 
 
@@ -13,6 +12,7 @@ core_plugins = [
     ('timers', timer.TimerPlugin),
 ]
 helper_plugins = [
+    ('chat', chat.ChatPlugin),
     ('clientinfo', clientinfo.ClientInfoPlugin),
     ('entities', entities.EntitiesPlugin),
     ('interact', interact.InteractPlugin),

--- a/spock/plugins/helpers/clientinfo.py
+++ b/spock/plugins/helpers/clientinfo.py
@@ -101,25 +101,25 @@ class ClientInfoPlugin(PluginBase):
     def handle_login_success(self, name, packet):
         self.client_info.uuid = packet.data['uuid']
         self.client_info.name = packet.data['username']
-        self.event.emit('cl_login_success')
+        self.event.emit('client_login_success')
 
     # Join Game - Update client state info
     def handle_join_game(self, name, packet):
         self.client_info.eid = packet.data['eid']
         self.client_info.game_info.set_dict(packet.data)
-        self.event.emit('cl_join_game', self.client_info.game_info)
+        self.event.emit('client_join_game', self.client_info.game_info)
 
     # Spawn Position - Update client Spawn Position state
     def handle_spawn_position(self, name, packet):
         self.client_info.spawn_position.set_dict(packet.data['location'])
-        self.event.emit('cl_spawn_update', self.client_info.spawn_position)
+        self.event.emit('client_spawn_update', self.client_info.spawn_position)
 
     # Update Health - Update client Health state
     def handle_update_health(self, name, packet):
         self.client_info.health.set_dict(packet.data)
-        self.event.emit('cl_health_update', self.client_info.health)
+        self.event.emit('client_health_update', self.client_info.health)
         if packet.data['health'] <= 0.0:
-            self.event.emit('cl_death', self.client_info.health)
+            self.event.emit('client_death', self.client_info.health)
 
     # Player Position and Look - Update client Position state
     def handle_position_update(self, name, packet):
@@ -131,7 +131,7 @@ class ClientInfoPlugin(PluginBase):
         p.z = p.z + d['z'] if f & FLG_ZPOS_REL else d['z']
         p.yaw = p.yaw + d['yaw'] if f & FLG_YROT_REL else d['yaw']
         p.pitch = p.pitch + d['pitch'] if f & FLG_XROT_REL else d['pitch']
-        self.event.emit('cl_position_update', self.client_info.position)
+        self.event.emit('client_position_update', self.client_info.position)
 
     # Player List Item - Update player list
     def handle_player_list(self, name, packet):
@@ -146,14 +146,14 @@ class ClientInfoPlugin(PluginBase):
                     del self.defered_pl[pl['uuid']]
                 self.client_info.player_list[pl['uuid']] = item
                 self.uuids[pl['uuid']] = item
-                self.event.emit('cl_add_player', item)
+                self.event.emit('client_add_player', item)
             elif act in [mcdata.PL_UPDATE_GAMEMODE,
                          mcdata.PL_UPDATE_LATENCY,
                          mcdata.PL_UPDATE_DISPLAY]:
                 if pl['uuid'] in self.uuids:
                     item = self.uuids[pl['uuid']]
                     item.set_dict(pl)
-                    self.event.emit('cl_update_player', item)
+                    self.event.emit('client_update_player', item)
                 # Sometime the server sends updates before it gives us the
                 # player. We store those in a list and apply them when
                 # ADD_PLAYER is sent
@@ -165,7 +165,7 @@ class ClientInfoPlugin(PluginBase):
                 item = self.uuids[pl['uuid']]
                 del self.client_info.player_list[pl['uuid']]
                 del self.uuids[pl['uuid']]
-                self.event.emit('cl_remove_player', item)
+                self.event.emit('client_remove_player', item)
 
     # Change Game State
     def handle_game_state(self, name, packet):

--- a/spock/plugins/helpers/entities.py
+++ b/spock/plugins/helpers/entities.py
@@ -89,7 +89,7 @@ class EntityCore(object):
 
 
 @pl_announce('Entities')
-class EntityPlugin(PluginBase):
+class EntitiesPlugin(PluginBase):
     requires = 'Event'
     events = {
         'PLAY<Join Game': 'handle_join_game',
@@ -116,7 +116,7 @@ class EntityPlugin(PluginBase):
     }
 
     def __init__(self, ploader, settings):
-        super(EntityPlugin, self).__init__(ploader, settings)
+        super(EntitiesPlugin, self).__init__(ploader, settings)
         self.ec = EntityCore()
         ploader.provides('Entities', self.ec)
 
@@ -134,7 +134,7 @@ class EntityPlugin(PluginBase):
         self.ec.entities[packet.data['eid']] = entity
         self.ec.players[packet.data['eid']] = entity
         self.event.emit('entity_spawn', {'entity': entity})
-        self.event.emit('player_spawn', entity)
+        self.event.emit('entity_player_spawn', entity)
 
     def handle_spawn_object(self, event, packet):
         entity = ObjectEntity()
@@ -149,7 +149,7 @@ class EntityPlugin(PluginBase):
         self.ec.entities[packet.data['eid']] = entity
         self.ec.mobs[packet.data['eid']] = entity
         self.event.emit('entity_spawn', {'entity': entity})
-        self.event.emit('mob_spawn', entity)
+        self.event.emit('entity_mob_spawn', entity)
 
     def handle_spawn_painting(self, event, packet):
         entity = PaintingEntity()
@@ -206,7 +206,7 @@ class EntityPlugin(PluginBase):
         if packet.data['eid'] in self.ec.entities:
             self.ec.entities[packet.data['eid']].set_dict(packet.data)
         if packet.data['eid'] == self.ec.client_player.eid:
-            self.event.emit('player_velocity', packet.data)
+            self.event.emit('entity_player_velocity', packet.data)
 
     def handle_set_dict(self, event, packet):
         if packet.data['eid'] in self.ec.entities:

--- a/spock/plugins/helpers/movement.py
+++ b/spock/plugins/helpers/movement.py
@@ -29,9 +29,9 @@ class MovementPlugin(PluginBase):
     events = {
         'client_tick': 'client_tick',
         'action_tick': 'action_tick',
-        'cl_position_update': 'handle_position_update',
-        'phy_collision': 'handle_collision',
-        'cl_join_game': 'handle_join_game',
+        'client_position_update': 'handle_position_update',
+        'physics_collision': 'handle_collision',
+        'client_join_game': 'handle_join_game',
     }
 
     def __init__(self, ploader, settings):
@@ -48,7 +48,7 @@ class MovementPlugin(PluginBase):
         self.net.push_packet('PLAY>Player Position and Look',
                              self.clientinfo.position.get_dict())
         if self.flag_pos_reset:
-            self.event.emit('position_reset')
+            self.event.emit('movement_position_reset')
             self.flag_pos_reset = False
 
     def handle_join_game(self, name, data):

--- a/spock/plugins/helpers/physics.py
+++ b/spock/plugins/helpers/physics.py
@@ -68,7 +68,7 @@ class PhysicsPlugin(PluginBase):
     requires = ('Event', 'ClientInfo', 'World')
     events = {
         'physics_tick': 'tick',
-        'cl_position_update': 'stop_physics',
+        'client_position_update': 'stop_physics',
         'position_reset': 'start_physics',
     }
 

--- a/spock/plugins/helpers/respawn.py
+++ b/spock/plugins/helpers/respawn.py
@@ -13,7 +13,7 @@ logger = logging.getLogger('spock')
 class RespawnPlugin(PluginBase):
     requires = ('Net', 'ClientInfo')
     events = {
-        'cl_death': 'handle_death'
+        'client_death': 'handle_death'
     }
 
     # You be dead

--- a/spock/plugins/helpers/world.py
+++ b/spock/plugins/helpers/world.py
@@ -53,9 +53,9 @@ class WorldPlugin(PluginBase):
         self.event.emit('world_time_update', packet.data)
 
     # Join Game/Respawn - New Dimension
-    def handle_neworld_dimension(self, name, packet):
-        self.world.neworld_dimension(packet.data['dimension'])
-        self.event.emit('world_neworld_dimension', packet.data['dimension'])
+    def handle_new_dimension(self, name, packet):
+        self.world.new_dimension(packet.data['dimension'])
+        self.event.emit('world_new_dimension', packet.data['dimension'])
 
     # Chunk Data - Update World state
     def handle_chunk_data(self, name, packet):

--- a/spock/plugins/helpers/world.py
+++ b/spock/plugins/helpers/world.py
@@ -21,7 +21,7 @@ class WorldData(smpmap.Dimension):
         self.age = data['world_age']
         self.time_of_day = data['time_of_day']
 
-    def new_dimension(self, dimension):
+    def neworld_dimension(self, dimension):
         super(WorldData, self).__init__(dimension)
 
     def reset(self):
@@ -32,8 +32,8 @@ class WorldData(smpmap.Dimension):
 class WorldPlugin(PluginBase):
     requires = 'Event'
     events = {
-        'PLAY<Join Game': 'handle_new_dimension',
-        'PLAY<Respawn': 'handle_new_dimension',
+        'PLAY<Join Game': 'handle_neworld_dimension',
+        'PLAY<Respawn': 'handle_neworld_dimension',
         'PLAY<Time Update': 'handle_time_update',
         'PLAY<Chunk Data': 'handle_chunk_data',
         'PLAY<Multi Block Change': 'handle_multi_block_change',
@@ -50,12 +50,12 @@ class WorldPlugin(PluginBase):
     # Time Update - Update World Time
     def handle_time_update(self, name, packet):
         self.world.update_time(packet.data)
-        self.event.emit('w_time_update', packet.data)
+        self.event.emit('world_time_update', packet.data)
 
     # Join Game/Respawn - New Dimension
-    def handle_new_dimension(self, name, packet):
-        self.world.new_dimension(packet.data['dimension'])
-        self.event.emit('w_new_dimension', packet.data['dimension'])
+    def handle_neworld_dimension(self, name, packet):
+        self.world.neworld_dimension(packet.data['dimension'])
+        self.event.emit('world_neworld_dimension', packet.data['dimension'])
 
     # Chunk Data - Update World state
     def handle_chunk_data(self, name, packet):
@@ -70,7 +70,7 @@ class WorldPlugin(PluginBase):
             z = block['z'] + chunk_z
             y = block['y']
             self.world.set_block(x, y, z, data=block['block_data'])
-            self.event.emit('w_block_update', {
+            self.event.emit('world_block_update', {
                 'location': {
                     'x': x,
                     'y': y,
@@ -84,7 +84,7 @@ class WorldPlugin(PluginBase):
         p = packet.data['location']
         block_data = packet.data['block_data']
         self.world.set_block(p['x'], p['y'], p['z'], data=block_data)
-        self.event.emit('w_block_update', packet.data)
+        self.event.emit('world_block_update', packet.data)
 
     # Map Chunk Bulk - Update World state
     def handle_map_chunk_bulk(self, name, packet):
@@ -92,4 +92,4 @@ class WorldPlugin(PluginBase):
 
     def handle_disconnect(self, name, data):
         self.world.reset()
-        self.event.emit('w_world_reset')
+        self.event.emit('world_world_reset')

--- a/spock/plugins/helpers/world.py
+++ b/spock/plugins/helpers/world.py
@@ -21,7 +21,7 @@ class WorldData(smpmap.Dimension):
         self.age = data['world_age']
         self.time_of_day = data['time_of_day']
 
-    def neworld_dimension(self, dimension):
+    def new_dimension(self, dimension):
         super(WorldData, self).__init__(dimension)
 
     def reset(self):

--- a/spock/plugins/helpers/world.py
+++ b/spock/plugins/helpers/world.py
@@ -32,8 +32,8 @@ class WorldData(smpmap.Dimension):
 class WorldPlugin(PluginBase):
     requires = 'Event'
     events = {
-        'PLAY<Join Game': 'handle_neworld_dimension',
-        'PLAY<Respawn': 'handle_neworld_dimension',
+        'PLAY<Join Game': 'handle_new_dimension',
+        'PLAY<Respawn': 'handle_new_dimension',
         'PLAY<Time Update': 'handle_time_update',
         'PLAY<Chunk Data': 'handle_chunk_data',
         'PLAY<Multi Block Change': 'handle_multi_block_change',
@@ -92,4 +92,4 @@ class WorldPlugin(PluginBase):
 
     def handle_disconnect(self, name, data):
         self.world.reset()
-        self.event.emit('world_world_reset')
+        self.event.emit('world_reset')


### PR DESCRIPTION
Create more useful event names and prevent namespace collisions. This should close #134. I did not change inventory due to #135 