### PR TITLE
Make entity metadata a dict, allow metadata for all entities

### DIFF
--- a/spock/mcp/datautils.py
+++ b/spock/mcp/datautils.py
@@ -153,11 +153,12 @@ metadata_lookup = MC_BYTE, MC_SHORT, MC_INT, MC_FLOAT, MC_STRING, MC_SLOT
 
 
 def unpack_metadata(bbuff):
-    metadata = []
+    metadata = {}
     head = unpack(MC_UBYTE, bbuff)
     while head != 0x7F:
         key = head & 0x1F  # Lower 5 bits
         typ = head >> 5  # Upper 3 bits
+        assert key not in metadata, 'k=%s t=%s' % (key, typ)
         if 0 <= typ < len(metadata_lookup):
             val = unpack(metadata_lookup[typ], bbuff)
         elif typ == 6:
@@ -172,15 +173,14 @@ def unpack_metadata(bbuff):
             val = [pitch, yaw, roll]
         else:
             return None
-        metadata.append((key, (typ, val)))
+        metadata[key] = (typ, val)
         head = unpack(MC_UBYTE, bbuff)
     return metadata
 
 
 def pack_metadata(data):
     o = b''
-    for key, tmp in data:
-        typ, val = tmp
+    for key, (typ, val) in data.items():
         o += pack(MC_UBYTE, (typ << 5) | key)
         if 0 <= typ < len(metadata_lookup):
             o += pack(metadata_lookup[typ], val)

--- a/spock/plugins/helpers/entities.py
+++ b/spock/plugins/helpers/entities.py
@@ -1,21 +1,14 @@
 """
 An entity tracker
 """
-import logging
-
 from spock.plugins.base import PluginBase
 from spock.utils import Info, pl_announce
-
-logger = logging.getLogger('spock')
 
 
 class MCEntity(Info):
     eid = 0
     status = 0
     nbt = None
-
-
-class ClientPlayerEntity(MCEntity):
     metadata = None
 
 
@@ -78,7 +71,7 @@ class GlobalEntity(MCEntity):
 
 class EntityCore(object):
     def __init__(self):
-        self.client_player = ClientPlayerEntity()
+        self.client_player = MCEntity()
         self.entities = {}
         self.players = {}
         self.mobs = {}


### PR DESCRIPTION
Fixes the bug that the `metadata` from the `Entity Metadata` packet was silently discarded.

This is needed to for example determine the type of a dropped item.