### PR TITLE
New event: world_chunk_update

### DIFF
--- a/spockbot/plugins/helpers/world.py
+++ b/spockbot/plugins/helpers/world.py
@@ -71,7 +71,7 @@ class WorldPlugin(PluginBase):
             x = block['x'] + chunk_x
             z = block['z'] + chunk_z
             y = block['y']
-            self.world.set_block(x, y, z, data=block['block_data'])
+            old_data = self.world.set_block(x, y, z, data=block['block_data'])
             self.event.emit('world_block_update', {
                 'location': {
                     'x': x,
@@ -79,14 +79,19 @@ class WorldPlugin(PluginBase):
                     'z': z,
                 },
                 'block_data': block['block_data'],
+                'old_data': old_data,
             })
 
     def handle_block_change(self, name, packet):
         """Block Change - Update a single block"""
         p = packet.data['location']
         block_data = packet.data['block_data']
-        self.world.set_block(p['x'], p['y'], p['z'], data=block_data)
-        self.event.emit('world_block_update', packet.data)
+        old_data = self.world.set_block(p['x'], p['y'], p['z'], data=block_data)
+        self.event.emit('world_block_update', {
+            'location': p,
+            'block_data': block_data,
+            'old_data': old_data,
+        })
 
     def handle_map_chunk_bulk(self, name, packet):
         """Map Chunk Bulk - Update World state"""

--- a/spockbot/plugins/helpers/world.py
+++ b/spockbot/plugins/helpers/world.py
@@ -62,6 +62,8 @@ class WorldPlugin(PluginBase):
     def handle_chunk_data(self, name, packet):
         """Chunk Data - Update World state"""
         self.world.unpack_column(packet.data)
+        location = packet.data['chunk_x'], packet.data['chunk_z']
+        self.event.emit('world_chunk_update', {'location': location})
 
     def handle_multi_block_change(self, name, packet):
         """Multi Block Change - Update multiple blocks"""
@@ -96,6 +98,9 @@ class WorldPlugin(PluginBase):
     def handle_map_chunk_bulk(self, name, packet):
         """Map Chunk Bulk - Update World state"""
         self.world.unpack_bulk(packet.data)
+        for meta in packet.data['metadata']:
+            location = meta['chunk_x'], meta['chunk_z']
+            self.event.emit('world_chunk_update', {'location': location})
 
     def handle_update_sign(self, event, packet):
         location = Vector3(packet.data['location'])

--- a/spockbot/plugins/helpers/world.py
+++ b/spockbot/plugins/helpers/world.py
@@ -86,11 +86,12 @@ class WorldPlugin(PluginBase):
 
     def handle_block_change(self, name, packet):
         """Block Change - Update a single block"""
-        p = packet.data['location']
+        pos = packet.data['location']
         block_data = packet.data['block_data']
-        old_data = self.world.set_block(p['x'], p['y'], p['z'], data=block_data)
+        old_data = self.world.set_block(pos['x'], pos['y'], pos['z'],
+                                        data=block_data)
         self.event.emit('world_block_update', {
-            'location': p,
+            'location': pos,
             'block_data': block_data,
             'old_data': old_data,
         })

--- a/spockbot/plugins/tools/smpmap.py
+++ b/spockbot/plugins/tools/smpmap.py
@@ -256,7 +256,10 @@ class Dimension(object):
 
         if data is None:
             data = (block_id << 4) | (meta & 0x0F)
+
+        old_data = chunk.block_data.get(rx, ry, rz)
         chunk.block_data.set(rx, ry, rz, data)
+        return old_data >> 4, old_data & 0x0F
 
     def get_block_entity_data(self, pos_or_x, y=None, z=None):
         """


### PR DESCRIPTION
As there are 10 chunks in a `Map Chunk Bulk`, it might be more sensible to emit a single `world_chunks_update` instead to cut the amount of events by an order of magnitude, and for simplicity use the same event with a single-element list for single chunk updates.