### PR TITLE
Fix for #219

### DIFF
--- a/spockbot/plugins/core/net.py
+++ b/spockbot/plugins/core/net.py
@@ -170,6 +170,7 @@ class NetPlugin(PluginBase):
         'SOCKET_ERR': 'handle_err',
         'SOCKET_HUP': 'handle_hup',
         'PLAY<Disconnect': 'handle_disconnect',
+        'LOGIN<Disconnect': 'handle_login_disconnect',
         'HANDSHAKE>Handshake': 'handle_handshake',
         'LOGIN<Login Success': 'handle_login_success',
         'LOGIN<Set Compression': 'handle_comp',
@@ -258,6 +259,13 @@ class NetPlugin(PluginBase):
     def handle_disconnect(self, name, packet):
         logger.debug("NETPLUGIN: Disconnected: %s", packet.data['reason'])
         self.event.emit('net_disconnect', packet.data['reason'])
+
+    def handle_login_disconnect(self, name, packet):
+
+        reason = packet.data.get('json_data', {}).get('text', '???')
+
+        logger.debug("NETPLUGIN: Disconnected: %s", reason)
+        self.event.emit('net_disconnect', reason)
 
     # Kill event - Try to shutdown the socket politely
     def handle_kill(self, name, data):


### PR DESCRIPTION
This adds an event handler on the NetPlugin to handle disconnect packets received from a 1.9 server (which uses a slightly different data format than what we've seen before). This change allows clients to receive a descriptive error message rather than just a generic disconnect error.

Oh - forgot to mention too - the tox tests pass except for the 3.3 ones as I can't install 3.3 on OS X El Capitan. :( Hopefully that's ok.