### PR TITLE
test: add seed for random

### DIFF
--- a/tests/plugins/core/test_taskmanager.py
+++ b/tests/plugins/core/test_taskmanager.py
@@ -5,6 +5,8 @@ from unittest import TestCase
 from spockbot.plugins.core.taskmanager import TaskManager
 from spockbot.plugins.tools.task import Task, TaskFailed
 
+random.seed(42)
+
 
 class EventMock(object):
     def __init__(self):


### PR DESCRIPTION
Hello, in this PR I added a fixed `random.seed(42)` in the test file to ensure deterministic behavior for the test that rely on Python’s random module.

This change was motivated by the `emit_and_check`, which includes data that uses random. Without setting a seed, test outcomes could vary between runs, making it harder to debug or reproduce issues. By setting the seed once at the start of the test session, we improve consistency and test reliability.